### PR TITLE
Allow to set process unit from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ Main goal of `DMH` is to ensure that actions can be executed only when you are d
 <img width="1023" alt="dmh-flow" src="https://github.com/user-attachments/assets/63a5a1a9-c692-4ade-a971-073b807653fe" />
 
 1. User creates action
-2. DMH encrypt action with [age](https://github.com/FiloSottile/age)
+2. DMH encrypts action with [age](https://github.com/FiloSottile/age)
 3. DMH uploads encryption private key to Vault
 4. Vault encrypts private key with own key and saves it (Vault will `release` encryption private key when user will be considered dead)
 5. DMH saves encrypted action, discards plaintext action, discards private key (**from now, nobody is able to see unencrypted action, even DMH**)
-6. DMH will sent alive probes to user
-7. When user will ignore N probes (configured per action), she/he would be considered dead.
-8. When both DMH and Vault will decide that user is dead, Vault secrets will be released, actions would be decrypted and executed.
-9. After execution, DMH will remove encryption private key from Vault - to ensure that action will remain confidential (only valid for actions with `min_interval: 0`).
+6. When user will not be available for some time (configured per action), she/he would be considered dead.
+7. When both DMH and Vault will decide that user is dead, Vault secrets will be released, actions would be decrypted and executed.
+8. After execution, DMH will remove encryption private key from Vault - to ensure that action will remain confidential (only valid for actions with `min_interval: 0`).
 
 
 **To decrypt action, access to `DMH` and `Vault` is required - `DMH` stores encrypted data and `Vault` stores encryption key.**
@@ -33,7 +32,7 @@ Main goal of `DMH` is to ensure that actions can be executed only when you are d
 
 # Installation
 
-## Docker (recommendated)
+## Docker (recommended)
 ```
 docker run --name dead-man-hand -e DMH_CONFIG_FILE=/data/config.yaml -v /srv/dead-man-hand/data:/data -p 8080:8080 ghcr.io/bkupidura/dead-man-hand:latest
 ```

--- a/integration_test.go
+++ b/integration_test.go
@@ -24,10 +24,8 @@ func TestDMH(t *testing.T) {
 	clientUUID := "integration-test-client-uuid"
 	requiredEnvs := map[string]string{"DMH_CONFIG_FILE": configFile}
 
-	processMessagesInterval = 1
-	processMessagesIntervalUnit = time.Second
-	actionProcessAfterUnit = time.Second
-	actionMinIntervalUnit = time.Second
+	getActionsInterval = 1
+	getActionsIntervalUnit = time.Second
 
 	f, err := os.Create(stateFile)
 	defer os.Remove(stateFile)
@@ -56,6 +54,8 @@ func TestDMH(t *testing.T) {
       file: %s
     state:
       file: %s
+    action:
+      process_unit: second
     remote_vault:
       url: http://127.0.0.1:8080
       client_uuid: %s

--- a/internal/vault/opts.go
+++ b/internal/vault/opts.go
@@ -1,6 +1,11 @@
 package vault
 
+import (
+	"time"
+)
+
 type Options struct {
-	Key      string
-	SavePath string
+	Key               string
+	SavePath          string
+	SecretProcessUnit time.Duration
 }

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -41,22 +41,37 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			inputOptions: &Options{
-				SavePath: vaultFile,
-				Key:      "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SavePath:          vaultFile,
+				Key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SecretProcessUnit: time.Hour,
 			},
 			expectedVault: func() VaultInterface {
 				return &Vault{
-					data:     map[string]*VaultData{},
-					key:      "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
-					savePath: vaultFile,
+					data:              map[string]*VaultData{},
+					key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+					savePath:          vaultFile,
+					secretProcessUnit: time.Hour,
 				}
 			},
 			vaultPathFunc: func() {},
 		},
 		{
 			inputOptions: &Options{
-				SavePath: vaultFile,
-				Key:      "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SavePath:          vaultFile,
+				Key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SecretProcessUnit: time.Millisecond,
+			},
+			expectedVault: func() VaultInterface {
+				return nil
+			},
+			expectedError: fmt.Errorf("SecretProcessUnit must be bigger than second"),
+			vaultPathFunc: func() {},
+		},
+		{
+			inputOptions: &Options{
+				SavePath:          vaultFile,
+				Key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SecretProcessUnit: time.Second,
 			},
 			expectedVault: func() VaultInterface {
 				return nil
@@ -72,8 +87,9 @@ func TestNew(t *testing.T) {
 		},
 		{
 			inputOptions: &Options{
-				SavePath: vaultFile,
-				Key:      "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SavePath:          vaultFile,
+				Key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+				SecretProcessUnit: time.Hour,
 			},
 			expectedVault: func() VaultInterface {
 				mockTime, err := time.Parse("2006-01-02T15:04:05.999999-07:00", "2025-03-26T14:55:40.119447+01:00")
@@ -103,8 +119,9 @@ func TestNew(t *testing.T) {
 							},
 						},
 					},
-					key:      "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
-					savePath: vaultFile,
+					key:               "AGE-SECRET-KEY-1WCXTESPDAL64QQLNE6SEHHSFQVHZ2KV7KR2XCLGQ0UFSUUJXP5AS84HFG0",
+					savePath:          vaultFile,
+					secretProcessUnit: time.Hour,
 				}
 			},
 			vaultPathFunc: func() {
@@ -187,7 +204,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -218,7 +236,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -249,7 +268,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -282,7 +302,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -315,7 +336,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -348,7 +370,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -384,7 +407,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -424,7 +448,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -463,7 +488,8 @@ func TestGetSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -528,7 +554,8 @@ func TestAddSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -566,7 +593,8 @@ func TestAddSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -607,7 +635,8 @@ func TestAddSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -650,7 +679,8 @@ func TestAddSecret(t *testing.T) {
 							},
 						},
 					},
-					key: "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					key:               "AGE-SECRET-KEY-1GEUMZFAZD42WGZFGATTTJHV4SURK8LU507QVCAKXKJP6UTFMJTCS0E3QJ4",
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -730,6 +760,7 @@ func TestDeleteSecret(t *testing.T) {
 							},
 						},
 					},
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -775,6 +806,7 @@ func TestDeleteSecret(t *testing.T) {
 							},
 						},
 					},
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -822,6 +854,7 @@ func TestDeleteSecret(t *testing.T) {
 							},
 						},
 					},
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -869,6 +902,7 @@ func TestDeleteSecret(t *testing.T) {
 							},
 						},
 					},
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},
@@ -907,6 +941,7 @@ func TestDeleteSecret(t *testing.T) {
 							},
 						},
 					},
+					secretProcessUnit: time.Hour,
 				}
 				return v
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"dmh/internal/execute"
+	"dmh/internal/state"
+	"dmh/internal/vault"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadingConfig(t *testing.T) {
+	tests := []struct {
+		inputConfig  func()
+		envConfigVar string
+		mockStateNew func(*state.Options) (state.StateInterface, error)
+	}{
+		{
+			inputConfig: func() {
+			},
+		},
+		{
+			inputConfig: func() {
+			},
+			envConfigVar: "non-existing.yaml",
+		},
+		{
+			inputConfig: func() {
+				f, err := os.Create("existing.yaml")
+				require.Nil(t, err)
+				defer f.Close()
+				_, err = f.WriteString(`
+                                components: ['dmh']
+                                state:
+                                  file: test.yaml
+                                action:
+                                  process_unit: minute
+                                remote_vault:
+                                  url: http://127.0.0.1:8080
+                                  client_uuid: uuid`)
+				require.Nil(t, err)
+			},
+			envConfigVar: "existing.yaml",
+			mockStateNew: func(*state.Options) (state.StateInterface, error) {
+				return nil, fmt.Errorf("mockStateNew error")
+			},
+		},
+	}
+	for _, test := range tests {
+		test.inputConfig()
+		if test.envConfigVar != "" {
+			err := os.Setenv("DMH_CONFIG_FILE", test.envConfigVar)
+			require.Nil(t, err)
+			defer os.Remove(test.envConfigVar)
+		} else {
+			os.Unsetenv("DMH_CONFIG_FILE")
+		}
+		stateNew = state.New
+		if test.mockStateNew != nil {
+			stateNew = test.mockStateNew
+			defer func() {
+				stateNew = state.New
+			}()
+		}
+		require.Panics(t, main)
+	}
+}
+
+func TestComponentsErrors(t *testing.T) {
+	tests := []struct {
+		mockStateNew   func(*state.Options) (state.StateInterface, error)
+		mockExecuteNew func(*execute.Options) (execute.ExecuteInterface, error)
+		mockVaultNew   func(*vault.Options) (vault.VaultInterface, error)
+	}{
+		{
+			mockStateNew: func(*state.Options) (state.StateInterface, error) {
+				return nil, fmt.Errorf("mockStateNew error")
+			},
+		},
+		{
+			mockExecuteNew: func(*execute.Options) (execute.ExecuteInterface, error) {
+				return nil, fmt.Errorf("mockExecuteNew error")
+			},
+		},
+		{
+			mockVaultNew: func(*vault.Options) (vault.VaultInterface, error) {
+				return nil, fmt.Errorf("mockVaultNew error")
+			},
+		},
+	}
+	f, err := os.Create("TestDMHComponentErrors.yaml")
+	defer os.Remove("TestDMHComponentErrors.yaml")
+	require.Nil(t, err)
+	defer f.Close()
+	_, err = f.WriteString(`
+               components: ['dmh', 'vault']
+               state:
+                 file: test.yaml
+               remote_vault:
+                 url: http://test.com
+                 client_uuid: uuid
+               vault:
+                 file: test2.yaml
+                 key: key
+             `)
+	require.Nil(t, err)
+	err = os.Setenv("DMH_CONFIG_FILE", "TestDMHComponentErrors.yaml")
+	require.Nil(t, err)
+	for _, test := range tests {
+		stateNew = state.New
+		if test.mockStateNew != nil {
+			stateNew = test.mockStateNew
+			defer func() {
+				stateNew = state.New
+			}()
+		}
+		executeNew = execute.New
+		if test.mockExecuteNew != nil {
+			executeNew = test.mockExecuteNew
+			defer func() {
+				executeNew = execute.New
+			}()
+		}
+		vaultNew = vault.New
+		if test.mockVaultNew != nil {
+			vaultNew = test.mockVaultNew
+			defer func() {
+				vaultNew = vault.New
+			}()
+		}
+		require.Panics(t, main)
+	}
+}


### PR DESCRIPTION
Allow to set `action.process_unit` from config.

This is used by `DMH` to decide what unit (minute, hour) `action.ProcessAfter` and `action.MinInterval` is using.

This is used by `Vault` to decide what unit (minute, hour) `secret.ProcessAfter` is using.

Config definition:
```
action:
  process_unit: minute
```

Supported values are 'second', 'minute' or 'hour' (default).

'second' should be never used, its supported only for testing.